### PR TITLE
Fixed a probable copy and paste error in rp2040Init

### DIFF
--- a/pico_neopixels/Adafruit_NeoPixel.cpp
+++ b/pico_neopixels/Adafruit_NeoPixel.cpp
@@ -233,7 +233,7 @@ void Adafruit_NeoPixel::rp2040Init(uint8_t set_pin)
 		if (resultsm != -1) {
 			if (pio1_offset == -1) {
 				canpio = pio_can_add_program(pio1, &ws2812byte_program);
-				if (canpio) pio1_offset = pio_add_program(pio0, &ws2812byte_program);
+				if (canpio) pio1_offset = pio_add_program(pio1, &ws2812byte_program);
 			};
 			pio = pio1;
 		}


### PR DESCRIPTION
When adding a program to pio1, pio0 was being used in the call to pio_add_program() rather than pio1.